### PR TITLE
Change calculation to use DOMParser instead regex

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,121 +1,130 @@
-document.getElementById('form').addEventListener('submit', onSubmit)
+(function(window, document) {
+  document.getElementById('form').addEventListener('submit', onSubmit)
 
-function onSubmit (event) {
-  event.preventDefault()
-  const htmlCode = getHtmlCode()
-
-  if(!htmlCode) {
-    return
-  }
-
-  const codeReport = generateCodeReport(htmlCode)
-  renderResults(codeReport)
-}
-
-function getHtmlCode () {
-  return document.getElementById('code').value
-}
-
-function generateCodeReport (html) {
-  const tagsAnalysis = analyseTags(html)
-  const proportionality = calculateGeneralProportionality(html)
-  return {
-    tags: tagsAnalysis,
-    proportionality
-  }
-}
-
-function analyseTags (html) {
-  const tagsCountMap = countTags(html)
-  const tags = Object.keys(tagsCountMap)
-  const tagsAnalysis = tags.map(tag => ({
-    tag,
-    count: tagsCountMap[tag],
-  }))
-  return tagsAnalysis.sort(compareTagsMetrics('count'))
-}
-
-function compareTagsMetrics (metric) {
-  return (a, b) => {
-    const metricA = a[metric]
-    const metricB = b[metric]
-    if (metricA > metricB) {
-      return -1;
+  function onSubmit (event) {
+    event.preventDefault()
+  
+    const htmlCode = getHtmlCode()
+  
+    if(!htmlCode) {
+      return
     }
-
-    if (metricA < metricB) {
-      return 1;
-    }
-
-    return 0;
+  
+    const codeReport = generateCodeReport(htmlCode)
+    renderResults(codeReport)
   }
-}
-
-function countTags (html) {
-  const regex = /<((?:\w|-)+)(?:\s|>)/g
-  const tags = [...html.matchAll(regex)].map(([_, tag]) => tag)
-  return tags.reduce((tagsCount, tag) => {
-    if (!tagsCount[tag]) {
-      tagsCount[tag] = 0
-    }
-
-    tagsCount[tag]++
-    return tagsCount
-  }, {})
-}
-
-function calculateGeneralProportionality (html) {
-  const temp = document.createElement('div')
-  temp.innerHTML = html
-
-  const formattedHtml = formatText(temp.innerHTML)
-  const content = formatText(temp.innerText)
-
-  const totalLength = formattedHtml.length
-  const contentPercentage = getPercentage(content.length, totalLength)
-  const codePercentage = getPercentage(totalLength - content.length, totalLength)
-
-  return {
-    content: contentPercentage,
-    code: codePercentage
+  
+  function getHtmlCode () {
+    return document.getElementById('code').value
   }
-}
-
-function formatText (text) {
-  return text.replace(/\n|(\s\s+)/g, '').trim()
-}
-
-function getPercentage (value, total) {
-  const percentage = value / total * 100
-  return percentage.toFixed(2)
-}
-
-function renderResults ({ proportionality, tags }) {
-  const proportionalityText = `
-    <h2>General proportionality:</h2>
-    <p><strong>Code:</strong> ${proportionality.code}%</p>
-    <p><strong>Content:</strong> ${proportionality.content}%</p>
-  `
-
-  const tagsText = `
-    <h2>Tags:</h2>
-    <table>
-      <thead>
-        <tr>
-          <td><strong>Tag</strong></td>
-          <td><strong>Count</strong></td>
-        </tr>
-      </thead>
-      <tbody>
-        ${tags.map(({tag, count}) => `
+  
+  function generateCodeReport (html) {
+    const report = getReport(html)
+    const proportionality = calculateGeneralProportionality(report)
+  
+    return {
+      report,
+      proportionality
+    }
+  }
+  
+  function getReport (html) {
+    var doc = new DOMParser().parseFromString(html, "text/html");
+  
+    allTags = doc.getElementsByTagName('*')
+    allTagsCount = allTags.length
+  
+    report = {}
+  
+    for (let index = 0; index < allTags.length; index++) {
+      const element = allTags[index];
+  
+      tagName = element.tagName.toLowerCase()
+      text = extractText(element)
+  
+      outerHtml = formatText(element.outerHTML)
+      innerHTML = formatText(element.innerHTML)
+      tagLength = outerHtml.length - innerHTML.length
+  
+      report[tagName] = {
+        count: (report[tagName]?.count || 0) + 1,
+        tagLength: (report[tagName]?.tagLength  || 0) + tagLength,
+        textLength: (report[tagName]?.textLength || 0) + text.length
+      }
+    }
+  
+    return report
+  }
+  
+  function extractText(element) {
+    excludedElements = ['script', 'style']
+    
+    if (excludedElements.indexOf(element.tagName.toLowerCase()) === -1) {
+      text = '';
+      for (var i = 0; i < element.childNodes.length; ++i)
+        if (element.childNodes[i].nodeType === Node.TEXT_NODE)
+          text += element.childNodes[i].textContent;
+      return formatText(text)
+    }
+    
+    return ''
+  }
+  
+  function calculateGeneralProportionality (report) {
+    totalTagLength = 0
+    totalTextLength = 0
+  
+    for (const tagReport of Object.values(report)) {
+      totalTagLength += tagReport.tagLength
+      totalTextLength += tagReport.textLength
+    }
+  
+    const totalLength = totalTagLength + totalTextLength
+    const contentPercentage = getPercentage(totalTextLength, totalLength)
+    const codePercentage = getPercentage(totalTagLength, totalLength)
+  
+    return {
+      content: contentPercentage,
+      code: codePercentage
+    }
+  }
+  
+  function formatText (text) {
+    return text.replace(/\n|(\s\s+)/g, '').trim()
+  }
+  
+  function getPercentage (value, total) {
+    const percentage = value / total * 100
+    return percentage.toFixed(2)
+  }
+  
+  function renderResults ({ proportionality, report }) {
+    const proportionalityText = `
+      <h2>General proportionality:</h2>
+      <p><strong>Code:</strong> ${proportionality.code}%</p>
+      <p><strong>Content:</strong> ${proportionality.content}%</p>
+    `
+  
+    const tagsText = `
+      <h2>Tags:</h2>
+      <table>
+        <thead>
           <tr>
-            <td><strong>${tag}</strong></td>
-            <td>${count}</td>
+            <td><strong>Tag</strong></td>
+            <td><strong>Count</strong></td>
           </tr>
-        `).join('\n')}
-      </tbody>
-    </table>
-  `
-
-  document.getElementById('results').innerHTML = proportionalityText + tagsText
-}
+        </thead>
+        <tbody>
+          ${Object.entries(report).map(([tag, data]) => `
+            <tr>
+              <td><strong>${tag}</strong></td>
+              <td>${data.count}</td>
+            </tr>
+          `).join('\n')}
+        </tbody>
+      </table>
+    `
+  
+    document.getElementById('results').innerHTML = proportionalityText + tagsText
+  }
+})(window, document)


### PR DESCRIPTION
Resolves #1 by changing the calculation method to use DOMParser instead regex. This way we can use outerHTML, InnerHTML and TEXT_NODE content to calculate while traversing the DOM tree.